### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,5 +1,8 @@
 name: Build and Deploy Jekyll Site
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/Anattasati/Anattasati.github.io/security/code-scanning/1](https://github.com/Anattasati/Anattasati.github.io/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block at the root level of the workflow file. This block will apply to all jobs that do not have their own `permissions` key, including the `build` job. The `permissions` block should specify the least privileges required for the workflow to operate correctly. Based on the workflow's actions, the `build` job only needs `contents: read` permissions to fetch and build the site.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
