### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,5 +1,8 @@
 name: Security Audit
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/Anattasati/Anattasati.github.io/security/code-scanning/2](https://github.com/Anattasati/Anattasati.github.io/security/code-scanning/2)

To resolve the issue, add the `permissions` key to the root of the workflow (`.github/workflows/security.yml`). This will apply least-privilege permissions to all jobs in the workflow. Since the workflow only requires read access to repository contents for auditing purposes, set `contents: read`. This ensures no unnecessary write permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
